### PR TITLE
URL flattening.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.foundersandcoders.com
+foundersandcoders.com


### PR DESCRIPTION
In order for the site to redirect to `https://foundersandcoders.com` from `www.` requests this change needs to be made. This is purely aesthetic!