### PR TITLE
update "Programme" page

### DIFF
--- a/_harp/programme/_overview.md
+++ b/_harp/programme/_overview.md
@@ -1,38 +1,32 @@
-We have graduated more than 150 students on our full-time programme. Over the last two years, more than 90% of our graduates have gone on to work in software or a related field.
+We have graduated more than 180 students on our full-time programmes in [London](./course-information/london) and [Nazareth](./course-information/nazareth). Over the last two years, more than 90% of our graduates have gone on to work in software or a related field.
 
-We believe that high quality education should be accessible to everyone. Our students continue to be involved with our programme long after they graduate. With their support and the work of the broader Founders & Coders community, we continue to offer our programme free at the point of delivery.
+We believe that high quality education should be accessible to everyone. Our students continue to be involved with our programme long after they graduate. With their support and the work of the broader Founders & Coders community, we continue to offer our programmes for free at the point of delivery.
 
-As of February 2017, we offer two programme locations: [London](/programme/course-information/london), UK and [Nazareth](/programme/course-information/nazareth), Israel.
+Founders & Coders welcomes applicants over 18 from all academic and professional backgrounds. We find that successful students are self-motivated, prepared to work long hours, and committed to collaborative working. Coding also requires a deep curiosity about how things work and a certain stubbornness in the face of repeated failure.
 
-### Pre-course introductory study
+### Self-learning and meetups
 
-Prospective students use online materials to teach themselves the fundamentals of programming and have the option to attend  weekly in-person meetups at the Founders & Coders campus while they are preparing and submitting their applications to the course.
+Prospective students use online materials to teach themselves the fundamentals of programming and have the option to attend weekly in-person meetups at the Founders & Coders campus while they are preparing and submitting their applications to the course.
 
-Visit [our Meetup site](http://www.meetup.com/founderscoders/) to learn more.
+### Prep-course
+
+After conducting interviews, we select a group of finalists for an in-person, weekly prep-course, where we provide support completing [our course prerequisites](../apply/prerequisites).
 
 ### 16-week full-time coding bootcamp
 
-Our programmes in Nazareth and London run three times a year. The dates for our 2017 cohorts are as follows:
- + 20th February - 9th June
- + **26th June - 13th October** ([applications open](http://www.foundersandcoders.com/apply/))
- + 23rd October - 23rd February
+Our immersive course is peer-led and project-based with sixteen students working in four teams of four. Students take turns delivering workshops, running code reviews and managing projects. The course covers test-driven development, using a full JavaScript stack (JavaScript and Node.js) with both relational databases, as well as aspects of UX design and product management.
 
-Our immersive course is peer-led and project-based with sixteen students working in four teams of four. Students take turns delivering seminars, running code reviews and managing projects. The course covers test-driven development, using a full JavaScript stack (JavaScript and Node.js) with both relational and non-relational databases, as well as aspects of UX design and product management.
+Our curriculum is an entirely open source project and is [available for viewing on GitHub](https://github.com/foundersandcoders/info/blob/master/curriculum.md).
 
-Read more about our curriculum [here](https://github.com/foundersandcoders/info/blob/master/curriculum.md).
-
-### 10-week full-time mentorship + portfolio building + job interviews:
+### 10-week full-time mentorship + portfolio building + job interviews
 
 During this period, every bootcamp graduate is expected to:
-
-* Spend up to twenty percent of their time mentoring the next cohort.
-* Complete up to four portfolio projects with local businesses, startups, or non-profit organisations.
-* Begin applying for positions with our recruitment partners.
++ Spend up to twenty percent of their time mentoring the next cohort.
++ Complete portfolio projects with local businesses, startups, or non-profit organisations.
++ Begin applying for positions with our recruitment partners.
 
 ### Employment
 
-Each place on the Founders & Coders programme costs us about £2,500 to provide. We ask you to consider either seeking employment with one of our partners who will help pay for these costs or, alternatively, making a regular voluntary contribution after you graduate as a way of 'paying it forward', so that we can provide a place for someone in a future cohort.
+Each place on the Founders & Coders programme costs us about £2,500 to provide. We ask you to consider either seeking employment with one of our partners who will help pay for these costs or, alternatively, making a regular voluntary contribution after you graduate. This is a way of 'paying it forward', so that we can provide a place for someone in a future cohort.
 
-Learn more about Founders & Coders Student agreement [here](https://github.com/foundersandcoders/charter/blob/master/README.md).
-
-### Employers
+To learn more, see the Founders & Coders [student agreement](https://github.com/foundersandcoders/charter/blob/master/README.md).

--- a/_harp/programme/_overview.md
+++ b/_harp/programme/_overview.md
@@ -10,11 +10,11 @@ Prospective students use online materials to teach themselves the fundamentals o
 
 ### Prep-course
 
-After conducting interviews, we select a group of finalists for an in-person, weekly prep-course, where we provide support completing [our course prerequisites](../apply/prerequisites).
+After conducting interviews, we select a group of finalists for an in-person, weekly prep-course, where we provide support completing [our course prerequisites](../apply/prerequisites) (note: this course is new and will be offered in Nazareth beginning in advance of the October course and in London before the February course).
 
 ### 16-week full-time coding bootcamp
 
-Our immersive course is peer-led and project-based with sixteen students working in four teams of four. Students take turns delivering workshops, running code reviews and managing projects. The course covers test-driven development, using a full JavaScript stack (JavaScript and Node.js) with both relational databases, as well as aspects of UX design and product management.
+Our immersive course is peer-led and project-based with sixteen students working in four teams of four. Students take turns delivering workshops, running code reviews and managing projects. The course covers test-driven development, using a full JavaScript stack (JavaScript and Node.js) with relational databases. We also teach aspects of UX design and project management.
 
 Our curriculum is an entirely open source project and is [available for viewing on GitHub](https://github.com/foundersandcoders/info/blob/master/curriculum.md).
 


### PR DESCRIPTION
+ update number of graduates that have gone through FAC
+ no longer refer to Nazareth as recently set up
+ link to campus-specific programme pages
+ add text about the ideal candidate e.g. self-motivated, committed to collaborative working, curious
+ mention interviews & prep course
+ remove specific programme dates
+ remove mention of non-relational databases being in the curriculum
+ mention that curriculum is open source

fixes #432