### PR TITLE
Remove references to Nazareth

### DIFF
--- a/_harp/about/_company.md
+++ b/_harp/about/_company.md
@@ -6,5 +6,3 @@
 
 <br>
 Founders & Coders is a UK-based nonprofit organization that runs a tuition-free coding academy in London. We have trained more than 150 students on our full-time programme. Over the last two years, more than 90% of our graduates have gone on to work in software or a related field. We generate income by charging recruitment fees when employers hire our graduates. We also provide technical expertise and training to nonprofits, local businesses and early-stage startups.
-
-In February 2017, we opened Founders & Coders Nazareth, our first international campus.  

--- a/_harp/about/_history.md
+++ b/_harp/about/_history.md
@@ -8,6 +8,4 @@ In November 2014, during the last week of the fourth cohort in Camden, we were i
 
 In January 2015, Ines and Nelson joined the team as a Director and Lead Technical Mentor respectively, bringing with them years of industry experience, and the fourth course began at Founders & Coders’ new home in Bethnal Green. Most of the third cohort stayed to organise the fourth course, providing critical mentorship and together, deepening the community ethos that continues to define Founders & Coders.
 
-Founders & Coders has become a highly selective programme with a reputation for producing outstanding graduates. In summer 2016, Dan met Rebecca Radding, an educator, and began planning for the international expansion of Founders & Coders, starting with Nazareth in February 2017.
-
-In late 2017, we began the process of incorporating a UK-based charity, Founders & Coders International, to support our international expansion efforts.
+In summer 2016, Dan met Rebecca Radding, an educator, and began planning for the international expansion of Founders & Coders, starting in the Middle East, where we now run two campuses.

--- a/_harp/apply/_apply.md
+++ b/_harp/apply/_apply.md
@@ -33,16 +33,4 @@ We welcome applicants from all backgrounds, though we particularly encourage app
 
 [More information about our London Programme.](https://foundersandcoders.com/programme/course-information/london)
 
-<h1 align='center'>NAZARETH</h1>
-
-**Eligibility:**
-
-The Nazareth programme is currently being funded by the Palestinian Welfare Association in partnership with the Nazareth Cultural and Tourism Association. Palestinians over 18 years age from both Israel and the West Bank are eligible to apply. If you are from the West Bank, we can apply for permits through a partnership with the Palestinian Internship Programme.
-
-**Selection Process:**
-
-We aim to offer at least eight spots for local students and at least four spots for international students. If needed, we will offer an in-person prep-course for local students in our classroom 2-3 evenings a week for four weeks prior to the start of the programme.
-
-[More information about our Nazareth Programme.](https://foundersandcoders.com/programme/course-information/nazareth)
-
 <h1 align='center'>APPLY NOW</h1>

--- a/_harp/apply/index.ejs
+++ b/_harp/apply/index.ejs
@@ -4,6 +4,5 @@
 	</div>
 	<div align="center" class="programmes-info">
 		<a href="https://docs.google.com/forms/d/e/1FAIpQLSepdNxKsrMjhfnbdkzKUgNpeWFmp8WLyiqTe_UY10TsPpFOEQ/viewform" target="_blank"><button class="button-three">LONDON</button></a>
-		<a href="https://goo.gl/vVg5Fm" target="_blank"><button class="button-three">NAZARETH</button></a>
 	</div>
 </div>

--- a/_harp/community/_team.md
+++ b/_harp/community/_team.md
@@ -4,7 +4,7 @@
 
 	<a href="https://www.linkedin.com/in/dsofer"  class="team-image dan"></a>
 
-	**Dan Sofer** is the founding director of *Founders & Coders C.I.C.* (our London programme) and is the director of *Founders & Coders International.* He has been building websites since 1995 for clients that include *The Guardian* and the *BBC*. He project managed the build of the official website of the *London 2012 Olympic Games*.
+	**Dan Sofer** is the founding director of *Founders & Coders C.I.C.*. He has been building websites since 1995 for clients that include *The Guardian* and the *BBC*. He project managed the build of the official website of the *London 2012 Olympic Games*.
 
 	<a href="https://www.linkedin.com/in/iteles"  class="team-image ines"></a>
 
@@ -12,11 +12,11 @@
 
 	<a href="https://www.linkedin.com/in/rebecca-radding"  class="team-image rebecca"></a>
 
-	**Rebecca Radding** has been a teacher, community organiser, and advocate for democratic education in the United States. Together with Dan, she has spearheaded the Founders & Coders expansion to the Middle East. She is currently behind development of *Founders & Coders International*, the UK-based charity that will be responsible for future expansion projects. She is based in Tangier, Morocco.
+	**Rebecca Radding** has been a teacher, community organiser, and advocate for democratic education in the United States. Together with Dan, she has spearheaded the Founders & Coders expansion to the Middle East. She is based in Tangier, Morocco.
 
 	<a href="https://www.linkedin.com/in/liu-yvonne"  
 	class="team-image yvonne"></a>
 
-	**Yvonne Liu** leads operations for *Founders & Coders International*. She is an advocate for growing communities, open-source systems, accessible education, and previously led operations in Asia for *iFixit*. A graduate of *Founders & Coders London*, she now divides her time between our UK and Middle East campuses.
+	**Yvonne Liu** leads operations for *Founders & Coders*. She is an advocate for growing communities, open-source systems, accessible education, and previously led operations in Asia for *iFixit*. A graduate of *Founders & Coders London*, she now divides her time between our UK and Middle East campuses.
 
 </div>

--- a/_harp/index.ejs
+++ b/_harp/index.ejs
@@ -8,7 +8,6 @@
     </p>
     <div class="programmes-info">
         <a href="/programme/course-information/london"><button class="button-three">London</button></a>
-        <a href="/programme/course-information/nazareth"><button class="button-three">Nazareth</button></a>
     </div>
 
 </div>

--- a/_harp/programme/_overview.md
+++ b/_harp/programme/_overview.md
@@ -1,4 +1,4 @@
-We have graduated more than 180 students on our full-time programmes in [London](./course-information/london) and [Nazareth](./course-information/nazareth). Over the last two years, more than 90% of our graduates have gone on to work in software or a related field.
+We have graduated more than 200 students on our full-time programmes in [London](./course-information/london). Over the last two years, more than 90% of our graduates have gone on to work in software or a related field.
 
 We believe that high quality education should be accessible to everyone. Our students continue to be involved with our programme long after they graduate. With their support and the work of the broader Founders & Coders community, we continue to offer our programmes for free at the point of delivery.
 
@@ -10,7 +10,7 @@ Prospective students use online materials to teach themselves the fundamentals o
 
 ### Prep-course
 
-After conducting interviews, we select a group of finalists for an in-person, weekly prep-course, where we provide support completing [our course prerequisites](../apply/prerequisites) (note: this course is new and will be offered in Nazareth).
+After conducting interviews, we select a group of finalists for an in-person, weekly prep-course, where we provide support completing [our course prerequisites](../apply/prerequisites).
 
 ### 16-week full-time coding bootcamp
 
@@ -27,6 +27,6 @@ During this period, every bootcamp graduate is expected to:
 
 ### Employment
 
-Each place on the Founders & Coders programme costs us about £2,500 to provide. We ask you to consider either seeking employment with one of our partners who will help pay for these costs or, alternatively, making a regular voluntary contribution after you graduate. This is a way of 'paying it forward', so that we can provide a place for someone in a future cohort.
+Each place on the Founders & Coders programme costs us about £3,000 to provide. We ask you to consider either seeking employment with one of our partners who will help pay for these costs or, alternatively, making a regular voluntary contribution after you graduate. This is a way of 'paying it forward', so that we can provide a place for someone in a future cohort.
 
 To learn more, see the Founders & Coders [student agreement](https://github.com/foundersandcoders/charter/blob/master/README.md).


### PR DESCRIPTION
In advance of the new site launching, remove Nazareth references from home, apply, programme and story pages.